### PR TITLE
feat: allow user to override the vertical offset

### DIFF
--- a/src/single.typ
+++ b/src/single.typ
@@ -7,6 +7,8 @@
   /// -> auto
   ..text-params,
 
+  offset: 0.4em,
+
   /// Sets the background color of the chord. *Optional*.
   /// -> color
   background: rgb(0, 0, 0, 0),
@@ -38,7 +40,7 @@
   }
 
   let horizontal-offset = 0pt
-  let vertical-offset = 1.2em
+  let vertical-offset = 0.8em + offset
   let anchor = center
 
   let size = (:)


### PR DESCRIPTION
Hi,

I didn't see any contributors guideline, so I'm just sending this PR out of the blue.

The title basically says it all: I wanted to be able to adjust the distance between the chords and the text, which can now be done using an optional parameter. Not using that parameter leaves the behavior unchanged to what it was previously.

Why do I want this? Example from my project with the default value:
<img width="90" height="130" alt="image" src="https://github.com/user-attachments/assets/f4b59b79-1c79-4f41-9401-feb121e5e9fb" />
And now with a modified (reduced) offset of 0.1em:
<img width="90" height="111" alt="image" src="https://github.com/user-attachments/assets/09474d2e-f1e5-42eb-84c7-9e06259d914c" />
Which results in a more compact text and looks (in my eyes) better. (The screenshots are cropped so strongly to avoid copyright issues.)

Let me know if this works for you, if I need to change anything, or if there's some process to follow...

Best Regards
Andreas