### PR TITLE
feat: set chord before word by chosing position 0

### DIFF
--- a/src/single.typ
+++ b/src/single.typ
@@ -29,6 +29,7 @@
 
   /// Positions the chord on a specific body character. *Required*.
   ///  - ```typ []```: chord name centered on the body.
+  ///  - ```typ [0]```: chord placed before the body.
   ///  - ```typ [number]```: the chord name starts on a specific body character. (First position ```typ [1]```)
   /// -> content
   position
@@ -48,6 +49,7 @@
   }
 
   let horizontal-offset = 0pt
+  let horizontal-preshift = 0pt
   let vertical-offset = 0em
   let anchor = center
 
@@ -60,21 +62,25 @@
     assert(has-number(position.at("text")) == true, message: "the \"position\" must to be a \"content\" with only numbers")
 
     let pos = int(position.at("text")) - 1
-    let min-pos = 0
-    let max-pos = body-array.len() - 1
-    pos = calc.clamp(pos, min-pos, max-pos)
-
-    let body-chars-offset = measure([#body-array.slice(0, pos).join()]).width
-
-    // gets the char-offset to center the first character of
-    // the chord with the selected character of the body
     let chord-char = parse-content(name).at(0)
     let chord-char-width = measure(text(..text-params)[#chord-char]).width
-    let body-char-width = measure([#body-array.at(pos)]).width
-    let char-offset = (chord-char-width - body-char-width) / 2
+    if(pos >= 0) {
+      let min-pos = 0
+      let max-pos = body-array.len() - 1
+      pos = calc.clamp(pos, min-pos, max-pos)
 
-    // final horizontal offset
-    horizontal-offset = body-chars-offset - char-offset
+      let body-chars-offset = measure([#body-array.slice(0, pos).join()]).width
+
+      // gets the char-offset to center the first character of
+      // the chord with the selected character of the body
+      let body-char-width = measure([#body-array.at(pos)]).width
+      let char-offset = (chord-char-width - body-char-width) / 2
+
+      // final horizontal offset
+      horizontal-offset = body-chars-offset - char-offset
+    } else {
+      horizontal-preshift = chord-char-width
+    }
     anchor = left
   }
 
@@ -92,7 +98,7 @@
   size.canvas.width = {
     if horizontal-offset > 0pt and size.name.width + horizontal-offset >= size.body.width {
       size.name.width + horizontal-offset
-    } else if horizontal-offset <= 0pt and size.name.width >= size.body.width {
+    } else if horizontal-offset <= 0pt and size.name.width >= size.body.width + horizontal-preshift {
       size.name.width
     } else {
       size.body.width
@@ -100,7 +106,7 @@
   }
 
   box(
-    width: size.canvas.width,
+    width: size.canvas.width+horizontal-preshift,
     height: size.canvas.height, {
       place(
         anchor + bottom,
@@ -115,6 +121,7 @@
       )
       place(
         anchor + bottom,
+        dx: horizontal-preshift,
         box(..size.body, body)
       )
     }

--- a/src/single.typ
+++ b/src/single.typ
@@ -101,12 +101,12 @@
     } else if horizontal-offset <= 0pt and size.name.width >= size.body.width + horizontal-preshift {
       size.name.width
     } else {
-      size.body.width
+      size.body.width+horizontal-preshift
     }
   }
 
   box(
-    width: size.canvas.width+horizontal-preshift,
+    width: size.canvas.width,
     height: size.canvas.height, {
       place(
         anchor + bottom,


### PR DESCRIPTION
Hello,

I have an edge case I'd like to introduce: When a word doesn't start on the first beat of a measure, e.g. like this:
<img width="316" height="85" alt="image" src="https://github.com/user-attachments/assets/49b86c8a-4b4f-4efc-abed-52cb09030a41" />
I like to set the chord symbol before the beginning of the word, like this:
<img width="180" height="63" alt="image" src="https://github.com/user-attachments/assets/a37acb9c-d389-47f4-8608-1345af83c175" />
It is triggered by giving `0` as `position` for the chord. E.g. for above example:
`#chord[der][C][0] Spuk #chord[vorbei][G][4]`

This PR implements this in a way, that shifts the entire word below the chord by the width of the first letter of the chord, so that a multi-line stanza doesn't get a ragged left edge. E.g.:
<img width="62" height="163" alt="image" src="https://github.com/user-attachments/assets/15545d15-2a2d-4338-9125-be79d9412a99" />
It also ensures that the chord isn't moved above the last letter of the previous word, e.g.:
<img width="116" height="54" alt="image" src="https://github.com/user-attachments/assets/d1f76300-bfb5-48c3-a57e-9f9cd94b07f9" />
for:
`schon #chord[der][C][0]`

It does not change the behavior for non-zero values of `position`.

Best Regards,
Andreas