### PR TITLE
feat: add manual transpose for chart and piano chords

### DIFF
--- a/src/chart.typ
+++ b/src/chart.typ
@@ -400,6 +400,16 @@
   /// -> color
   background: rgb(0, 0, 0, 0),
 
+  /// Sets the current transpose. *Optional*.
+  /// This works in conjuntion with `show-transpose`.
+  /// -> int
+  for-transpose: 0,
+
+  /// Shows the transpose defined by `for-transpose`. *Optional*.
+  /// This works in conjuntion with `for-transpose`.
+  /// -> int
+  show-transpose: 0,
+
   /// Shows the chord name. *Required*.
   /// -> str | content
   name
@@ -409,10 +419,16 @@
   assert.eq(type(capos), str)
   assert.eq(type(frets-amount), int)
   assert.eq(type(background), color)
+  assert.eq(type(for-transpose), int)
+  assert.eq(type(show-transpose), int)
   assert(type(fret) == int or fret == none, message: "type of 'fret' must to be 'int' or 'none'")
   assert(type(name) in (str, content), message: "type of 'name' must to be 'str' or 'content'")
   assert(design in ("sharp", "round"), message: "'design' must to be '\"sharp\"' or '\"round\"'")
   assert(position in ("bottom", "top"), message: "'position' must to be '\"bottom\"' or '\"top\"'")
+
+  if for-transpose != show-transpose {
+    return none
+  }
 
   let tabs = parse-input-string(tabs)
   let fingers = parse-input-string(fingers)

--- a/src/piano.typ
+++ b/src/piano.typ
@@ -430,6 +430,16 @@
   /// -> color
   background: rgb(0, 0, 0, 0),
 
+  /// Sets the current transpose. *Optional*.
+  /// This works in conjuntion with `show-transpose`.
+  /// -> int
+  for-transpose: 0,
+
+  /// Shows the transpose defined by `for-transpose`. *Optional*.
+  /// This works in conjuntion with `for-transpose`.
+  /// -> int
+  show-transpose: 0,
+
   /// Shows the chord name. *Required*.
   /// -> str | content
   name
@@ -437,10 +447,16 @@
   assert.eq(type(keys), str)
   assert.eq(type(fill-key), color)
   assert.eq(type(background), color)
+  assert.eq(type(for-transpose), int)
+  assert.eq(type(show-transpose), int)
   assert(upper(layout) in ("C", "2C", "F", "2F"), message: "`layout` must to be \"C\", \"2C\", \"F\" or \"2F\"")
   assert(design in ("sharp", "round"), message: "`design` must to be \"sharp\" or \"round\"")
   assert(position in ("bottom", "top"), message: "'position' must to be '\"bottom\"' or '\"top\"'")
   assert(type(name) in (str, content), message: "type of `name` must to be `str` or `content`")
+
+  if for-transpose != show-transpose {
+    return none
+  }
 
   let (size, font, ..text-params) = set-default-arguments(text-params.named())
 


### PR DESCRIPTION
### Summary
Implements manual chord transposition for `chart-chord` and `piano-chords` functions.

### Key Features:
- Adds `for-transpose` and `show-transpose` fields. If the `for-transpose == show-transpose` the chord is visualized. 
- You can manually generate all transposition variations with full control of the chart and display only the specific transposition.
